### PR TITLE
Update utf8.c

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -90,7 +90,7 @@ unsigned unicode_to_utf8(unsigned int c, char *utf8)
 			bytes++;
 			prefix >>= 1;
 			c >>= 6;
-		} while (c > prefix);
+		} while (c >= prefix);
 		*p = c - 2*prefix;
 		reverse_string(utf8, p);
 	}


### PR DESCRIPTION
The function unicode_to_utf8 was failing to produce the correct leading byte of the UTF8 sequence because the loop was stopping one iteration too soon.